### PR TITLE
Adding letters to buttons along with other UI tweaking configurations (backwards compatible)

### DIFF
--- a/app/src/main/java/com/andrognito/pinlockviewapp/SampleActivity.java
+++ b/app/src/main/java/com/andrognito/pinlockviewapp/SampleActivity.java
@@ -52,7 +52,6 @@ public class SampleActivity extends AppCompatActivity {
         //mPinLockView.enableLayoutShuffling();
 
         mPinLockView.setPinLength(4);
-        mPinLockView.setTextColor(ContextCompat.getColor(this, R.color.white));
 
         mIndicatorDots.setIndicatorType(IndicatorDots.IndicatorType.FILL_WITH_ANIMATION);
     }

--- a/app/src/main/res/layout/activity_sample.xml
+++ b/app/src/main/res/layout/activity_sample.xml
@@ -47,6 +47,7 @@
         app:keypadButtonSize="72dp"
         app:keypadShowDeleteButton="true"
         app:keypadTextColor="@color/white"
-        app:keypadTextSize="18dp" />
+        app:keypadUseDeprecatedColorOptions="true"
+        app:keypadDefaultDeleteColor="true"/>
 
 </RelativeLayout>

--- a/pinlockview/src/main/java/com/andrognito/pinlockview/CustomizationOptionsBundle.java
+++ b/pinlockview/src/main/java/com/andrognito/pinlockview/CustomizationOptionsBundle.java
@@ -10,13 +10,23 @@ import android.graphics.drawable.Drawable;
  */
 public class CustomizationOptionsBundle {
 
+    private int numberTextColor;
+    private int lettersTextColor;
+    private int deleteButtonColor;
     private int textColor;
     private int textSize;
+    private int numberTextSize;
+    private int lettersTextSize;
+    private boolean showLetters;
+    private boolean isNumbersTextBold;
+    private boolean isLettersTextBold;
+    private boolean isDeleteDefaultColor;
     private int buttonSize;
     private Drawable buttonBackgroundDrawable;
     private Drawable deleteButtonDrawable;
     private int deleteButtonSize;
     private boolean showDeleteButton;
+    private boolean useDeprecated;
     private int deleteButtonPressesColor;
 
     public CustomizationOptionsBundle() {
@@ -25,17 +35,98 @@ public class CustomizationOptionsBundle {
     public int getTextColor() {
         return textColor;
     }
-
+  
     public void setTextColor(int textColor) {
         this.textColor = textColor;
     }
-
+  
     public int getTextSize() {
         return textSize;
     }
-
+  
     public void setTextSize(int textSize) {
         this.textSize = textSize;
+    }
+
+    public int getNumbersTextColor() {
+        return numberTextColor;
+    }
+
+    public void setNumbersTextColor(int textColor) {
+        this.numberTextColor = textColor;
+    }
+
+    public int getLettersTextColor() {
+        return lettersTextColor;
+    }
+
+    public void setLettersTextColor(int textColor) {
+        this.lettersTextColor = textColor;
+    }
+
+    public int getNumbersTextSize() {
+        return numberTextSize;
+    }
+
+    public void setNumbersTextSize(int textSize) {
+        this.numberTextSize = textSize;
+    }
+
+    public int getLettersTextSize() {
+        return lettersTextSize;
+    }
+
+    public void setLettersTextSize(int textSize) {
+        this.lettersTextSize = textSize;
+    }
+
+    public boolean getShowLetters() {
+        return showLetters;
+    }
+
+    public void setShowLetters(boolean showLetters) {
+        this.showLetters = showLetters;
+    }
+
+    // Deprecated colour options
+    public boolean getUseDeprecated() {
+        return useDeprecated;
+    }
+
+    public void setUseDeprecated(boolean useDeprecated) {
+        this.useDeprecated = useDeprecated;
+    }
+
+    public int getDeleteButtonColor() {
+        return deleteButtonColor;
+    }
+
+    public void setDeleteButtonColor(int defaultColor) {
+        this.deleteButtonColor = defaultColor;
+    }
+
+    public boolean getDeleteButtonDefault() {
+        return isDeleteDefaultColor;
+    }
+
+    public void setDeleteButtonDefault(boolean isDefaultColor) {
+        this.isDeleteDefaultColor = isDefaultColor;
+    }
+
+    public boolean getIsNumbersTextBold() {
+        return isNumbersTextBold;
+    }
+
+    public void setIsNumbersTextBold(boolean isNumbersTextBold) {
+        this.isNumbersTextBold = isNumbersTextBold;
+    }
+
+    public boolean getIsLettersTextBold() {
+        return isLettersTextBold;
+    }
+
+    public void setIsLettersTextBold(boolean isLettersTextBold) {
+        this.isLettersTextBold = isLettersTextBold;
     }
 
     public int getButtonSize() {

--- a/pinlockview/src/main/java/com/andrognito/pinlockview/PinLockAdapter.java
+++ b/pinlockview/src/main/java/com/andrognito/pinlockview/PinLockAdapter.java
@@ -13,6 +13,8 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
+import android.widget.TextView;
+import android.graphics.Typeface;
 
 /**
  * Created by aritraroy on 31/05/16.
@@ -65,14 +67,89 @@ public class PinLockAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         if (holder != null) {
             if (position == 9) {
                 holder.mNumberButton.setVisibility(View.GONE);
+                holder.number.setVisibility(View.GONE);
+                holder.letters.setVisibility(View.GONE);
             } else {
-                holder.mNumberButton.setText(String.valueOf(mKeyValues[position]));
+                holder.number.setText(String.valueOf(mKeyValues[position]));
                 holder.mNumberButton.setVisibility(View.VISIBLE);
+                holder.number.setVisibility(View.VISIBLE);
                 holder.mNumberButton.setTag(mKeyValues[position]);
+
             }
 
             if (mCustomizationOptionsBundle != null) {
-                holder.mNumberButton.setTextColor(mCustomizationOptionsBundle.getTextColor());
+                // If using deprecated color options, then text color and size affects
+                // both the numbers and text. Otherwise, the number and text colors are
+                // assigned separately
+                if(mCustomizationOptionsBundle.getUseDeprecated()){
+                    holder.number.setTextColor(mCustomizationOptionsBundle.getTextColor());
+                    holder.letters.setTextColor(mCustomizationOptionsBundle.getTextColor());
+
+                    holder.number.setTextSize(TypedValue.COMPLEX_UNIT_PX,
+                            mCustomizationOptionsBundle.getTextSize());
+                    holder.letters.setTextSize(TypedValue.COMPLEX_UNIT_PX,
+                            mCustomizationOptionsBundle.getTextSize());
+                } else {
+                    // Set text colors
+                    holder.number.setTextColor(mCustomizationOptionsBundle.getNumbersTextColor());
+                    holder.letters.setTextColor(mCustomizationOptionsBundle.getLettersTextColor());
+
+                    // Set text sizes
+                    holder.number.setTextSize(TypedValue.COMPLEX_UNIT_PX,
+                            mCustomizationOptionsBundle.getNumbersTextSize());
+                    holder.letters.setTextSize(TypedValue.COMPLEX_UNIT_PX,
+                            mCustomizationOptionsBundle.getLettersTextSize());
+                }
+
+                // Set up letters
+                if (mCustomizationOptionsBundle.getShowLetters()) {
+                    holder.letters.setVisibility(View.VISIBLE);
+                    if (holder != null && position != 9) {
+                        switch (mKeyValues[position]) {
+                            case 1:
+                                holder.letters.setVisibility(View.INVISIBLE);
+                                break;
+                            case 2:
+                                holder.letters.setText(mContext.getResources().getString(R.string.button_two_text));
+                                break;
+                            case 3:
+                                holder.letters.setText(mContext.getResources().getString(R.string.button_three_text));
+                                break;
+                            case 4:
+                                holder.letters.setText(mContext.getResources().getString(R.string.button_four_text));
+                                break;
+                            case 5:
+                                holder.letters.setText(mContext.getResources().getString(R.string.button_five_text));
+                                break;
+                            case 6:
+                                holder.letters.setText(mContext.getResources().getString(R.string.button_six_text));
+                                break;
+                            case 7:
+                                holder.letters.setText(mContext.getResources().getString(R.string.button_seven_text));
+                                break;
+                            case 8:
+                                holder.letters.setText(mContext.getResources().getString(R.string.button_eight_text));
+                                break;
+                            case 9:
+                                holder.letters.setText(mContext.getResources().getString(R.string.button_nine_text));
+                                break;
+                            case 0:
+                                holder.letters.setVisibility(View.GONE);
+                                break;
+                        }
+                    }
+                }
+
+                // Set boldness of text
+                if (mCustomizationOptionsBundle.getIsNumbersTextBold()) {
+                    holder.number.setTypeface(null, Typeface.BOLD);
+                }
+
+                if (mCustomizationOptionsBundle.getIsLettersTextBold()) {
+                    holder.letters.setTypeface(null, Typeface.BOLD);
+                }
+
+                // Set button backgrounds
                 if (mCustomizationOptionsBundle.getButtonBackgroundDrawable() != null) {
                     if (Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.JELLY_BEAN) {
                         holder.mNumberButton.setBackgroundDrawable(
@@ -82,8 +159,8 @@ public class PinLockAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                                 mCustomizationOptionsBundle.getButtonBackgroundDrawable());
                     }
                 }
-                holder.mNumberButton.setTextSize(TypedValue.COMPLEX_UNIT_PX,
-                        mCustomizationOptionsBundle.getTextSize());
+
+                // Set button sizes
                 LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
                         mCustomizationOptionsBundle.getButtonSize(),
                         mCustomizationOptionsBundle.getButtonSize());
@@ -99,8 +176,13 @@ public class PinLockAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                 if (mCustomizationOptionsBundle.getDeleteButtonDrawable() != null) {
                     holder.mButtonImage.setImageDrawable(mCustomizationOptionsBundle.getDeleteButtonDrawable());
                 }
-                holder.mButtonImage.setColorFilter(mCustomizationOptionsBundle.getTextColor(),
+                if (mCustomizationOptionsBundle.getDeleteButtonDefault()) {
+                    holder.mButtonImage.setColorFilter(mCustomizationOptionsBundle.getNumbersTextColor(),
                         PorterDuff.Mode.SRC_ATOP);
+                } else {
+                    holder.mButtonImage.setColorFilter(mCustomizationOptionsBundle.getDeleteButtonColor(),
+                        PorterDuff.Mode.SRC_ATOP);
+                }
                 LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
                         mCustomizationOptionsBundle.getDeleteButtonSize(),
                         mCustomizationOptionsBundle.getDeleteButtonSize());
@@ -179,11 +261,15 @@ public class PinLockAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
     }
 
     public class NumberViewHolder extends RecyclerView.ViewHolder {
-        Button mNumberButton;
+        LinearLayout mNumberButton;
+        TextView number;
+        TextView letters;
 
         public NumberViewHolder(final View itemView) {
             super(itemView);
-            mNumberButton = (Button) itemView.findViewById(R.id.button);
+            mNumberButton = (LinearLayout) itemView.findViewById(R.id.button);
+            number = (TextView) itemView.findViewById(R.id.number);
+            letters = (TextView) itemView.findViewById(R.id.letters);
             mNumberButton.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
@@ -235,12 +321,22 @@ public class PinLockAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                             rect = new Rect(v.getLeft(), v.getTop(), v.getRight(), v.getBottom());
                         }
                         if (event.getAction() == MotionEvent.ACTION_UP) {
-                            mButtonImage.clearColorFilter();
+                            if (mCustomizationOptionsBundle.getDeleteButtonDefault()) {
+                                mButtonImage.clearColorFilter();
+                            } else {
+                                mButtonImage.setColorFilter(mCustomizationOptionsBundle.getDeleteButtonColor(),
+                                    PorterDuff.Mode.SRC_ATOP);
+                            }
                         }
                         if (event.getAction() == MotionEvent.ACTION_MOVE) {
                             if (!rect.contains(v.getLeft() + (int) event.getX(),
                                     v.getTop() + (int) event.getY())) {
-                                mButtonImage.clearColorFilter();
+                                if (mCustomizationOptionsBundle.getDeleteButtonDefault()) {
+                                    mButtonImage.clearColorFilter();
+                                } else {
+                                    mButtonImage.setColorFilter(mCustomizationOptionsBundle.getDeleteButtonColor(),
+                                        PorterDuff.Mode.SRC_ATOP);
+                                }
                             }
                         }
                         return false;

--- a/pinlockview/src/main/java/com/andrognito/pinlockview/PinLockView.java
+++ b/pinlockview/src/main/java/com/andrognito/pinlockview/PinLockView.java
@@ -24,11 +24,14 @@ public class PinLockView extends RecyclerView {
     private String mPin = "";
     private int mPinLength;
     private int mHorizontalSpacing, mVerticalSpacing;
-    private int mTextColor, mDeleteButtonPressedColor;
-    private int mTextSize, mButtonSize, mDeleteButtonSize;
+    private int mTextColor, mNumbersTextColor, mLettersTextColor, mDeleteButtonPressedColor, mDeleteButtonColor;
+    private int mTextSize, mNumbersTextSize, mLettersTextSize, mButtonSize, mDeleteButtonSize;
     private Drawable mButtonBackgroundDrawable;
     private Drawable mDeleteButtonDrawable;
-    private boolean mShowDeleteButton;
+    private boolean mShowDeleteButton, mShowLetters;
+    private boolean mNumbersTextBold, mLettersTextBold;
+    private boolean mDeleteButtonDefault;
+    private boolean mDeprecatedColorOptions;
 
     private IndicatorDots mIndicatorDots;
     private PinLockAdapter mAdapter;
@@ -144,27 +147,47 @@ public class PinLockView extends RecyclerView {
             mPinLength = typedArray.getInt(R.styleable.PinLockView_pinLength, DEFAULT_PIN_LENGTH);
             mHorizontalSpacing = (int) typedArray.getDimension(R.styleable.PinLockView_keypadHorizontalSpacing, ResourceUtils.getDimensionInPx(getContext(), R.dimen.default_horizontal_spacing));
             mVerticalSpacing = (int) typedArray.getDimension(R.styleable.PinLockView_keypadVerticalSpacing, ResourceUtils.getDimensionInPx(getContext(), R.dimen.default_vertical_spacing));
-            mTextColor = typedArray.getColor(R.styleable.PinLockView_keypadTextColor, ResourceUtils.getColor(getContext(), R.color.white));
-            mTextSize = (int) typedArray.getDimension(R.styleable.PinLockView_keypadTextSize, ResourceUtils.getDimensionInPx(getContext(), R.dimen.default_text_size));
+            mNumbersTextColor = typedArray.getColor(R.styleable.PinLockView_keypadNumbersTextColor, ResourceUtils.getColor(getContext(), R.color.white));
+            mLettersTextColor = typedArray.getColor(R.styleable.PinLockView_keypadLettersTextColor, ResourceUtils.getColor(getContext(), R.color.white));
+            mDeleteButtonColor = typedArray.getColor(R.styleable.PinLockView_keypadDeleteButtonColor, ResourceUtils.getColor(getContext(), R.color.white));
+            mNumbersTextSize = (int) typedArray.getDimension(R.styleable.PinLockView_keypadNumbersTextSize, ResourceUtils.getDimensionInPx(getContext(), R.dimen.default_text_size));
+            mLettersTextSize = (int) typedArray.getDimension(R.styleable.PinLockView_keypadLettersTextSize, ResourceUtils.getDimensionInPx(getContext(), R.dimen.default_text_size));
             mButtonSize = (int) typedArray.getDimension(R.styleable.PinLockView_keypadButtonSize, ResourceUtils.getDimensionInPx(getContext(), R.dimen.default_button_size));
             mDeleteButtonSize = (int) typedArray.getDimension(R.styleable.PinLockView_keypadDeleteButtonSize, ResourceUtils.getDimensionInPx(getContext(), R.dimen.default_delete_button_size));
             mButtonBackgroundDrawable = typedArray.getDrawable(R.styleable.PinLockView_keypadButtonBackgroundDrawable);
             mDeleteButtonDrawable = typedArray.getDrawable(R.styleable.PinLockView_keypadDeleteButtonDrawable);
             mShowDeleteButton = typedArray.getBoolean(R.styleable.PinLockView_keypadShowDeleteButton, true);
+            mNumbersTextBold = typedArray.getBoolean(R.styleable.PinLockView_keypadNumbersBold, false);
+            mLettersTextBold = typedArray.getBoolean(R.styleable.PinLockView_keypadLettersBold, false);
+            mDeleteButtonDefault = typedArray.getBoolean(R.styleable.PinLockView_keypadDefaultDeleteColor, true);
+            mShowLetters = typedArray.getBoolean(R.styleable.PinLockView_keypadShowLetters, false);
             mDeleteButtonPressedColor = typedArray.getColor(R.styleable.PinLockView_keypadDeleteButtonPressedColor, ResourceUtils.getColor(getContext(), R.color.greyish));
+            mDeprecatedColorOptions = typedArray.getBoolean(R.styleable.PinLockView_keypadUseDeprecatedColorOptions, true);
+            mTextColor = typedArray.getColor(R.styleable.PinLockView_keypadTextColor, ResourceUtils.getColor(getContext(), R.color.white));
+            mTextSize = (int) typedArray.getDimension(R.styleable.PinLockView_keypadTextSize, ResourceUtils.getDimensionInPx(getContext(), R.dimen.default_text_size));
         } finally {
             typedArray.recycle();
         }
 
         mCustomizationOptionsBundle = new CustomizationOptionsBundle();
+        mCustomizationOptionsBundle.setNumbersTextColor(mNumbersTextColor);
+        mCustomizationOptionsBundle.setNumbersTextSize(mNumbersTextSize);
+        mCustomizationOptionsBundle.setLettersTextColor(mLettersTextColor);
+        mCustomizationOptionsBundle.setLettersTextSize(mLettersTextSize);
         mCustomizationOptionsBundle.setTextColor(mTextColor);
         mCustomizationOptionsBundle.setTextSize(mTextSize);
         mCustomizationOptionsBundle.setButtonSize(mButtonSize);
+        mCustomizationOptionsBundle.setShowLetters(mShowLetters);
+        mCustomizationOptionsBundle.setDeleteButtonColor(mDeleteButtonColor);
+        mCustomizationOptionsBundle.setIsNumbersTextBold(mNumbersTextBold);
+        mCustomizationOptionsBundle.setIsLettersTextBold(mLettersTextBold);
         mCustomizationOptionsBundle.setButtonBackgroundDrawable(mButtonBackgroundDrawable);
         mCustomizationOptionsBundle.setDeleteButtonDrawable(mDeleteButtonDrawable);
         mCustomizationOptionsBundle.setDeleteButtonSize(mDeleteButtonSize);
         mCustomizationOptionsBundle.setShowDeleteButton(mShowDeleteButton);
         mCustomizationOptionsBundle.setDeleteButtonPressesColor(mDeleteButtonPressedColor);
+        mCustomizationOptionsBundle.setDeleteButtonDefault(mDeleteButtonDefault);
+        mCustomizationOptionsBundle.setUseDeprecated(mDeprecatedColorOptions);
 
         initView();
     }
@@ -250,6 +273,207 @@ public class PinLockView extends RecyclerView {
     public void setTextSize(int textSize) {
         this.mTextSize = textSize;
         mCustomizationOptionsBundle.setTextSize(textSize);
+        mAdapter.notifyDataSetChanged();
+    }
+
+    /**
+     * Get the text color in the buttons
+     *
+     * @return the text color of the numbers
+     */
+    public int getNumbersTextColor() {
+        return mNumbersTextColor;
+    }
+
+    /**
+     * Set the text color of the buttons dynamically
+     *
+     * @param textColor the text color for the numbers
+     */
+    public void setNumbersTextColor(int textColor) {
+        this.mNumbersTextColor = textColor;
+        mCustomizationOptionsBundle.setNumbersTextColor(textColor);
+        mAdapter.notifyDataSetChanged();
+    }
+
+    /**
+     * Get the text color in the buttons
+     *
+     * @return the text color of the letters
+     */
+    public int getLettersTextColor() {
+        return mLettersTextColor;
+    }
+
+    /**
+     * Set the text color of the buttons dynamically
+     *
+     * @param textColor the text color for the letters
+     */
+    public void setLettersTextColor(int textColor) {
+        this.mLettersTextColor = textColor;
+        mCustomizationOptionsBundle.setLettersTextColor(textColor);
+        mAdapter.notifyDataSetChanged();
+    }
+
+    /**
+     * Get the size of the numerical text in the buttons
+     *
+     * @return the size of the text in pixels
+     */
+    public int getNumbersTextSize() {
+        return mNumbersTextSize;
+    }
+
+    /**
+     * Set the size of numerical text in pixels
+     *
+     * @param textSize the text size in pixels
+     */
+    public void setNumbersTextSize(int textSize) {
+        this.mNumbersTextSize = textSize;
+        mCustomizationOptionsBundle.setNumbersTextSize(textSize);
+        mAdapter.notifyDataSetChanged();
+    }
+
+    /**
+     * Get the size of the alphabetical text in the buttons
+     *
+     * @return the size of the text in pixels
+     */
+    public int getLettersTextSize() {
+        return mLettersTextSize;
+    }
+
+    /**
+     * Set the size of the alphabetical text in pixels
+     *
+     * @param textSize the text size in pixels
+     */
+    public void setLettersTextSize(int textSize) {
+        this.mLettersTextSize = textSize;
+        mCustomizationOptionsBundle.setLettersTextSize(textSize);
+        mAdapter.notifyDataSetChanged();
+    }
+
+    /**
+     * Get the color of the delete button
+     *
+     * @return the delete button color
+     */
+    public int getDeleteButtonColor() {
+        return mDeleteButtonColor;
+    }
+
+    /**
+     * Set the color fo the delete button
+     *
+     * @param buttonColor the color of the delete button
+     */
+    public void setDeleteButtonColor(int buttonColor) {
+        this.mDeleteButtonColor = buttonColor;
+        mCustomizationOptionsBundle.setDeleteButtonColor(buttonColor);
+        mAdapter.notifyDataSetChanged();
+    }
+
+    /**
+     * Checks if the numbers text is bold
+     *
+     * @return returns true if numbers are bolded, false otherwise
+     */
+    public boolean isNumbersTextBold() {
+        return mNumbersTextBold;
+    }
+
+    /**
+     * Dynamically set the boldness of numbers text
+     *
+     * @param isNumbersBold true if the numbers text should be bold, false otherwise
+     */
+    public void setNumbersTextBold(boolean isNumbersBold) {
+        this.mNumbersTextBold = isNumbersBold;
+        mCustomizationOptionsBundle.setIsNumbersTextBold(isNumbersBold);
+        mAdapter.notifyDataSetChanged();
+    }
+
+    /**
+     * Checks if the letters text is bold
+     *
+     * @return returns true if letters are bolded, false otherwise
+     */
+    public boolean isLettersTextBold() {
+        return mLettersTextBold;
+    }
+
+    /**
+     * Dynamically set the boldness of letters text
+     *
+     * @param isLettersBold true if the letters text should be bold, false otherwise
+     */
+    public void setLettersTextBold(boolean isLettersBold) {
+        this.mLettersTextBold = isLettersBold;
+        mCustomizationOptionsBundle.setIsLettersTextBold(isLettersBold);
+        mAdapter.notifyDataSetChanged();
+    }
+
+    /**
+     * Are the letters in the keypad buttons shown
+     *
+     * @return returns true if shown, false otherwise
+     */
+    public boolean isShownLetters() {
+        return mShowLetters;
+    }
+
+    /**
+     * Dynamically set if the letters in buttons should be shown
+     *
+     * @param showLetters true if the letters in buttons should be shown, false otherwise
+     */
+    public void setShownLetters(boolean showLetters) {
+        this.mShowLetters = showLetters;
+        mCustomizationOptionsBundle.setShowLetters(showLetters);
+        mAdapter.notifyDataSetChanged();
+    }
+
+
+    /**
+     * Is the delete button of default color (white)
+     *
+     * @return returns true if it is default color, false otherwise
+     */
+    public boolean isDefaultDeleteColor() {
+        return mDeleteButtonDefault;
+    }
+
+    /**
+     * Dynamically set if the delete button is of default color
+     *
+     * @param showLetters true if the letters in buttons should be shown, false otherwise
+     */
+    public void setDefaultDeleteColor(boolean isDefaultColor) {
+        this.mDeleteButtonDefault = isDefaultColor;
+        mCustomizationOptionsBundle.setDeleteButtonDefault(isDefaultColor);
+        mAdapter.notifyDataSetChanged();
+    }
+
+    /**
+     * Are we using deprecated color options for color of numbers and letters
+     *
+     * @return returns true if it we are using the deprecated options, false otherwise
+     */
+    public boolean isUsingDeprecatedColorOptions() {
+        return mDeprecatedColorOptions;
+    }
+
+    /**
+     * Dynamically set if the delete button is of default color
+     *
+     * @param showLetters true if the letters in buttons should be shown, false otherwise
+     */
+    public void setDeprecatedColorOptions(boolean deprecatedColorOption) {
+        this.mDeprecatedColorOptions = deprecatedColorOption;
+        mCustomizationOptionsBundle.setUseDeprecated(deprecatedColorOption);
         mAdapter.notifyDataSetChanged();
     }
 
@@ -372,6 +596,8 @@ public class PinLockView extends RecyclerView {
         mCustomizationOptionsBundle.setDeleteButtonPressesColor(deleteButtonPressedColor);
         mAdapter.notifyDataSetChanged();
     }
+
+
 
     public int[] getCustomKeySet() {
         return mCustomKeySet;

--- a/pinlockview/src/main/res/layout-v21/layout_number_item.xml
+++ b/pinlockview/src/main/res/layout-v21/layout_number_item.xml
@@ -6,10 +6,26 @@
     android:clipToPadding="false"
     android:orientation="vertical">
 
-    <Button
+    <LinearLayout
         android:id="@+id/button"
         android:layout_width="64dp"
         android:layout_height="64dp"
-        android:background="?android:attr/selectableItemBackgroundBorderless"/>
+        android:background="?android:attr/selectableItemBackgroundBorderless"
+        android:orientation="vertical"
+        android:gravity="center">
+
+        <TextView
+            android:id="@+id/number"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="20sp" />
+
+        <TextView
+            android:id="@+id/letters"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="invisible"
+            android:textSize="12sp" />
+    </LinearLayout>
 
 </LinearLayout>

--- a/pinlockview/src/main/res/values/attrs.xml
+++ b/pinlockview/src/main/res/values/attrs.xml
@@ -4,6 +4,11 @@
         <attr name="pinLength" format="integer" />
         <attr name="keypadTextColor" format="color" />
         <attr name="keypadTextSize" format="dimension" />
+        <attr name="keypadNumbersTextColor" format="color" />
+        <attr name="keypadLettersTextColor" format="color" />
+        <attr name="keypadDeleteButtonColor" format="color" />
+        <attr name="keypadNumbersTextSize" format="dimension" />
+        <attr name="keypadLettersTextSize" format="dimension" />
         <attr name="keypadButtonSize" format="dimension" />
         <attr name="keypadVerticalSpacing" format="dimension" />
         <attr name="keypadHorizontalSpacing" format="dimension" />
@@ -11,6 +16,11 @@
         <attr name="keypadDeleteButtonDrawable" format="integer" />
         <attr name="keypadDeleteButtonSize" format="dimension" />
         <attr name="keypadShowDeleteButton" format="boolean" />
+        <attr name="keypadUseDeprecatedColorOptions" format="boolean" />
+        <attr name="keypadShowLetters" format="boolean" />
+        <attr name="keypadNumbersBold" format="boolean" />
+        <attr name="keypadLettersBold" format="boolean" />
+        <attr name="keypadDefaultDeleteColor" format="boolean" />
         <attr name="keypadDeleteButtonPressedColor" format="color" />
 
         <attr name="dotEmptyBackground" format="reference" />

--- a/pinlockview/src/main/res/values/strings.xml
+++ b/pinlockview/src/main/res/values/strings.xml
@@ -1,3 +1,13 @@
 <resources>
     <string name="app_name">PinLockView</string>
+    <string name="button_one_text"></string>
+    <string name="button_two_text">A B C</string>
+    <string name="button_three_text">D E F</string>
+    <string name="button_four_text">G H I</string>
+    <string name="button_five_text">J K L</string>
+    <string name="button_six_text">M N O</string>
+    <string name="button_seven_text">P Q R S</string>
+    <string name="button_eight_text">T U V</string>
+    <string name="button_nine_text">W X Y Z</string>
+    <string name="button_zero_text"></string>
 </resources>


### PR DESCRIPTION
# Summary of changes

The goal of the changes is to add letters to the keypad under the numbers, as well as make some small changes, such as making the numbers bold and the color behavior of the back button (it used to turn the delete button white after clicking the delete button once, but now it will flash a predetermined color and then go back to the default color).

# Changes to Implementation

Each button used to be a "Button" in Android XML but I changed it to a LinearLayout to accommodate both the text and numbers in the button. I also split the variables **textColor** and **textSize** into **numberTextColor**, **lettersTextColor**, **numberTextSize**, **lettersTextSize**, and made appropriate addition of functions/changes to the code to reflect this.

Each button's text used to be set to a number depending on its position. I leveraged this to set each position a specified text as well.

# XML property changes

### Deprecated (but still compatible) XML Configurations :

- keypadTextColor: Sets color of both the numbers and the letters
- keypadTextSize: Sets size of both the numbers and letters

### Added XML Configurations:
- keypadUseDeprecatedColorOptions: Use the deprecated options on color and size over new options (set to false to use new ones)
- keypadNumbersTextColor: Sets the color of the numbers
- keypadNumbersTextSize: Sets the font size of the numbers
- keypadLettersTextColor: Sets the color of the letters
- keypadLettersTextSize: Sets the font size of the letters
- keypadShowLetters: Changes the visibility of the letters
- keypadNumbersBold: Sets the boldness of the numbers text
- keypadLettersBold: Sets the boldness of letter text
- keypadDeleteButtonColor: Sets the color of the delete button
- keypadDefaultDeleteColor: Set to true if you change the color of the delete button
# Snapshots of changes

## Before

![promo](https://user-images.githubusercontent.com/28817207/27564791-fc1328e6-5a8e-11e7-9deb-b4010504154d.png)

## After

<img width="322" alt="screen shot 2017-06-26 at 4 26 02 pm" src="https://user-images.githubusercontent.com/28817207/27564373-08303446-5a8c-11e7-8772-039724b470e4.png"> <img width="321" alt="screen shot 2017-06-26 at 4 49 25 pm" src="https://user-images.githubusercontent.com/28817207/27564826-43f81590-5a8f-11e7-9eac-70abc7659451.png">
